### PR TITLE
Arduino IDE Library Manager library.properties file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Max72xxPanel
+version=1.0.0
+author=Mark Ruys <mark@paracas.nl>
+maintainer=Mark Ruys <mark@paracas.nl>
+sentence=Library for controlling a canvas of sets of 8x8 LEDs driven by MAX7219 or MAX7221 controllers.
+paragraph=This is a plugin for Adafruit's core graphics library GFX, providing basic graphics primitives (points, lines, circles, characters, etc.). So besides this library, you need to download and install Adafruit_GFX, dated Jul 5th, 2013 or more recent.
+category=Display
+url=https://github.com/markruys/arduino-Max72xxPanel
+architectures=*


### PR DESCRIPTION
> Add a library.properties file so that the Arduino IDE Library Manager can show some more info about the library. For more info: [Arduino IDE 1.5 Library spec](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification)
> I'm ignoring the library spec requirement for library source files to be in a `src` subfolder as that can be ignored when library is to be backwards compatible with Arduino IDE 1.0.x
> One annoyance - a version must be specified - and it needs to be semver compliant, else I'd omit that field or use the hash for the latest commit.